### PR TITLE
Adds Indonesian (id_ID) to locales.

### DIFF
--- a/locales.json
+++ b/locales.json
@@ -89,5 +89,14 @@
         "phoneNumberExample": "+31 651165256",
         "translateCountry": true,
         "fallbackTimezone": "Europe/Amsterdam"
+    },
+    "id_ID": {
+        "label": "Indonesian",
+        "displayName": "bahasa Indonesia",
+        "callingCode": "+62",
+        "countryName": "Indonesia",
+        "phoneNumberExample": "+62 8342024961",
+        "translateCountry": true,
+        "fallbackTimezone": "Asia/Jakarta"
     }
 }


### PR DESCRIPTION
### Description
- Adds Indonesian (id_ID) to locales.

### Solution
- displayName from https://en.wikipedia.org/wiki/Indonesian_language
- phone number (mobile) example from: https://wikitravel.org/en/Wikitravel:Phone_numbers#Indonesia
- fallbackTime from: https://momentjs.com/timezone/
  - Set to Java (WIB) as most people live there
